### PR TITLE
Fix nits on build script and instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A toy WebAssembly app on LLVM WebAssembly backend, Binaryen, compiler-rt, musl, 
 # Usage
 
 ```
-git checkout https://github.com/tzik/wasm
+git clone https://github.com/tzik/wasm
 cd wasm
 ./bin/checkout
 ./configure

--- a/bin/checkout
+++ b/bin/checkout
@@ -2,7 +2,7 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-[ -d lib ] || mkdir lib
+mkdir -p lib
 cd lib
 [ -e "musl" ] || git clone --depth=1 "git://git.musl-libc.org/musl"
 [ -e "compiler-rt" ] || git clone --depth=1 "http://llvm.org/git/compiler-rt.git"

--- a/bin/checkout
+++ b/bin/checkout
@@ -2,9 +2,7 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-if [ ! -d lib ]; then
-  mkdir lib
-fi
+[ -d lib ] || mkdir lib
 cd lib
 [ -e "musl" ] || git clone --depth=1 "git://git.musl-libc.org/musl"
 [ -e "compiler-rt" ] || git clone --depth=1 "http://llvm.org/git/compiler-rt.git"

--- a/bin/checkout
+++ b/bin/checkout
@@ -2,6 +2,9 @@
 set -ex
 cd "$(dirname "$0")/.."
 
+if [ ! -d lib ]; then
+  mkdir lib
+fi
 cd lib
 [ -e "musl" ] || git clone --depth=1 "git://git.musl-libc.org/musl"
 [ -e "compiler-rt" ] || git clone --depth=1 "http://llvm.org/git/compiler-rt.git"


### PR DESCRIPTION
Current bin/checkout expects to create lib/ directory
under the current working directory manually, but Usage
does not explain it.

This patch fixes the bin/checkout script to create lib/
directory if it does not exit.

Also this fixes a nit, s/checkout/clone/, of README.md.
